### PR TITLE
Log the bin edges when histogramming on a log scale

### DIFF
--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -479,13 +479,17 @@ $(_example("barplot"))
 """)
 
 # Coordinates of the bars of a histogram of the values in `x`
-function hist(x, nbins=0, baseline=0.0)
-    if nbins <= 1
-        nbins = round(Int, 3.3 * log10(length(x))) + 1
-    end
+function hist(x, nbins=0, baseline=0.0, edges=nothing)
+    if edges === nothing
+        if nbins <= 1
+            nbins = round(Int, 3.3 * log10(length(x))) + 1
+        end
 
-    xmin, xmax = extrema(x)
-    edges = range(xmin, stop = xmax, length = nbins + 1)
+        xmin, xmax = extrema(x)
+        edges = range(xmin, stop = xmax, length = nbins + 1)
+    else
+        nbins=length(edges)-1
+    end
     counts = zeros(nbins)
     buckets = Int[max(2, min(searchsortedfirst(edges, xᵢ), length(edges)))-1 for xᵢ in x]
     for b in buckets
@@ -502,7 +506,7 @@ function hist(x, nbins=0, baseline=0.0)
     (wc, hc)
 end
 
-function _setargs_hist(f, x; nbins = 0, fillcolor=nothing, horizontal = false, kwargs...)
+function _setargs_hist(f, x; nbins = 0, fillcolor=nothing, horizontal = false, edges=nothing, kwargs...)
     if fillcolor ≠ nothing # deprecate?
         kwargs = (; color=fillcolor, kwargs...)
     end
@@ -512,7 +516,7 @@ function _setargs_hist(f, x; nbins = 0, fillcolor=nothing, horizontal = false, k
     else
         baseline = 0.0
     end
-    wc, hc = hist(x, nbins, baseline)
+    wc, hc = hist(x, nbins, baseline, edges)
     args = horizontal ? (hc, wc) : (wc, hc)
     return (args, kwargs)
 end
@@ -530,6 +534,8 @@ The following keyword arguments can be supplied:
     number of elements in `data`.
 * `horizontal`: whether the histogram should be horizontal (`false` by default).
 * `color`: hexadecimal RGB color code for the bars.
+* `edges`: vector of bin edges; by default, the edges chosen to be linearly spaced
+  over the range of the data. If `edges` is passed, `nbins` is set accordingly.
 
 !!! note
 

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -487,7 +487,7 @@ function logrange(lo, hi, n::Integer)
     elseif lo<0 && hi<0
         (-exp(x) for x in range(log(-lo), log(-hi), length=n))
     else
-        throw(DomainError(p, "logrange requires that first and last elements are both positive, or both negative"))
+        throw(DomainError((lo, hi), "logrange requires that first and last elements are both positive, or both negative"))
     end
 end
 
@@ -524,12 +524,12 @@ function _setargs_hist(f, x; nbins = 0, fillcolor=nothing, horizontal = false, k
         kwargs = (; color=fillcolor, kwargs...)
     end
     # Define baseline - 0.0 by default, unless using log scale
-    if get(kwargs, :ylog, false) || horizontal && get(kwargs, :xlog, false)
+    if !horizontal && get(kwargs, :ylog, false) || horizontal && get(kwargs, :xlog, false)
         baseline = 1.0
     else
         baseline = 0.0
     end
-    bins_log_scale =  get(kwargs, :xlog, false) || horizontal && get(kwargs, :ylog, false)
+    bins_log_scale =  !horizontal && get(kwargs, :xlog, false) || horizontal && get(kwargs, :ylog, false)
     wc, hc = hist(x, nbins, baseline, bins_log_scale)
     args = horizontal ? (hc, wc) : (wc, hc)
     return (args, kwargs)


### PR DESCRIPTION
This PR changes `histogram` to use log-scaled bin edges for making histograms with log-scale axes, using (the simplest version of) @mcabbott's code from https://github.com/JuliaLang/julia/pull/39071 (@mcabbott: is it OK to use your code for this here?).

I imagine it's breaking; if that's unacceptable, my first commit just adds an `edges` keyword argument to allow the user to pass custom histogram edges instead, so they can achieve the same thing by passing log-scaled edges themselves, so that would be a non-breaking way to be able to get this kind of plot.

# Example

With [AnalyzeRegistry.jl](https://github.com/giordano/AnalyzeRegistry.jl) I counted the number of lines of source code of all Julia packages, and was interested in plotting a histogram.

Without using a log scale, one can tell most packages have relatively few lines of code, and some packages have a ton:
```julia
histogram(lines_of_code, xlabel="Lines of Julia source code", ylabel="Number of packages")
```

![hist_no_log](https://user-images.githubusercontent.com/5846501/108607388-747a0180-73c0-11eb-9250-893ae32bc6a3.png)


But it's hard to get a good sense of the distribution. By making the `x`-axis a log-scale, on release GRUtils, I get

```julia
histogram(lines_of_code, xlog=true, xlabel="Lines of Julia source code", ylabel="Number of packages")
```

![hist](https://user-images.githubusercontent.com/5846501/108607343-19e0a580-73c0-11eb-9d9b-979a62fd2545.png)

which is not very nice looking. But with this PR, I get

![hist_bins_logged](https://user-images.githubusercontent.com/5846501/108607342-1816e200-73c0-11eb-97e0-e87c381bd0e8.png)

which shows a nice distribution and seems to be the most informative plot.
