### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-GR = "0.60"
+GR = "0.61"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Version v0.61.0 should fix the problems with `contour`, `tricont` etc.

To switch to the new 3D transformations (using `setspace3d`, `setwindow3d`), we have to apply several changes to the current GRUtils code. That's why I switched back to the old transformation schema (`setspace`) in a first step.