### PR TITLE
Restore compatibility with GR.jlgr

### DIFF
--- a/src/axes.jl
+++ b/src/axes.jl
@@ -91,7 +91,7 @@ function Axes(kind, geoms::Array{<:Geometry}; grid=1, kwargs...)
         set_ticklabels!(ticklabels; kwargs...)
     elseif kind == :axes3d
         tickdata = set_ticks(ranges, 2, (:x, :y, :z); kwargs...)
-        perspective = [Int(get(kwargs, :rotation, 40)), Int(get(kwargs, :tilt, 70))]
+        perspective = [Int(get(kwargs, :rotation, 40)), Int(get(kwargs, :tilt, 60))]
         options[:render3d] = render3d = get(kwargs, :render3d, 0)
         if render3d == 2
             cameradistance = get(kwargs, :cameradistance, 3.0)
@@ -479,7 +479,7 @@ function draw(ax::Axes, background=true)
         if ax.options[:render3d] == 1
             GR.setwindow3d(ax.ranges[:x]..., ax.ranges[:y]..., ax.ranges[:z]...)
             GR.setspace3d(-ax.perspective[1], ax.perspective[2], 30, 0)
-            GR.setcharheight(2*charheight)
+            GR.setcharheight(1.5*charheight)
         else
             GR.setspace(ax.ranges[:z]..., ax.perspective...)
         end

--- a/src/frontend.jl
+++ b/src/frontend.jl
@@ -1040,7 +1040,7 @@ $(_example("wireframe"))
 """)
 
 @plotfunction(trisurf, geom = :trisurf, axes = :axes3d, setargs = _setargs_tricont,
-kwargs = (colorbar=true, ratio=1.0), docstring="""
+kwargs = (colorbar=true, ratio=1.0, render3d=1), docstring="""
     tricont(x, y, z; kwargs...)
 
 Draw a triangular surface plot.

--- a/src/geometries.jl
+++ b/src/geometries.jl
@@ -477,6 +477,7 @@ function draw(g::Geometry, ::Val{:wireframe})::Nothing
 end
 
 function draw(g::Geometry, ::Val{:trisurf})::Nothing
+    GR.setwindow(-1, 1, -1, 1)
     GR.trisurface(g.x, g.y, g.z)
 end
 
@@ -534,6 +535,8 @@ function draw(g::Geometry, ::Val{:isosurf})::Nothing
             round(Int64, isovalue * (2^16-1)))
     GR.gr3.setbackgroundcolor(1, 1, 1, 0)
     GR.gr3.drawmesh(mesh, 1, (0, 0, 0), (0, 0, 1), (0, 1, 0), meshcolor, (1, 1, 1))
+    GR.gr3.setcameraprojectionparameters(45, 1, 200)
+
     vp = GR.inqviewport()
     GR.gr3.drawimage(vp..., 500, 500, GR.gr3.DRAWABLE_GKS)
     GR.gr3.deletemesh(mesh)


### PR DESCRIPTION
- use perspective projection for `trisurf`
- fix problem with `isosurface`
- slightly reduce character height

Note: the `GR.setwindow` command in `trisurf` is just a workaround. This setting has to be moved into the GR core.